### PR TITLE
Adding a link for MetalKit

### DIFF
--- a/example/ExampleApp/CMakeLists.txt
+++ b/example/ExampleApp/CMakeLists.txt
@@ -51,6 +51,7 @@ target_link_libraries(ExampleApp
     PRIVATE
     "-framework Cocoa"
     "-framework Metal"
+    "-framework MetalKit"
 )
 
 target_include_directories(ExampleApp


### PR DESCRIPTION
Example is failing to run independently because it's missing the link to MetalKit. Adding the link.