### PR TITLE
Always declare add_dependencies on embedded shader libraries

### DIFF
--- a/cmake/MetalShaderSupport.cmake
+++ b/cmake/MetalShaderSupport.cmake
@@ -39,13 +39,19 @@ function(target_embed_metal_shader_libraries TARGET)
         ""
     )
 
+    # Build-order dependency is required regardless of how the embedding is
+    # done: XCODE_EMBED_RESOURCES is a packaging hint and does not, by itself,
+    # cause CMake to build the shader library before the embed phase runs.
+    foreach(SHADERLIB IN LISTS _temsl_UNPARSED_ARGUMENTS)
+        add_dependencies(${TARGET} ${SHADERLIB})
+    endforeach()
+
     if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.28 AND ${CMAKE_GENERATOR} STREQUAL "Xcode")
         set_target_properties(${TARGET} PROPERTIES
             XCODE_EMBED_RESOURCES "${_temsl_UNPARSED_ARGUMENTS}"
         )
     else()
         foreach(SHADERLIB IN LISTS _temsl_UNPARSED_ARGUMENTS)
-            add_dependencies(${TARGET} ${SHADERLIB})
             add_custom_command(TARGET ${TARGET} POST_BUILD
                 COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE:${SHADERLIB}>" "$<TARGET_BUNDLE_CONTENT_DIR:${TARGET}>/Resources/$<TARGET_FILE_NAME:${SHADERLIB}>"
                 VERBATIM


### PR DESCRIPTION
target_embed_metal_shader_libraries() registers a build-order dependency on the listed shader libraries only on the non-Xcode-generator path. The Xcode path uses XCODE_EMBED_RESOURCES, which is a packaging hint that does not, by itself, make CMake build the shader library before the embed phase runs.

The result is a race: under parallel builds with the Xcode generator, the embed step can fire before the .metallib has been (re)built, so the embedded resource is either missing on the first build or stale on subsequent rebuilds. The non-Xcode path doesn't have this problem because it explicitly calls add_dependencies() for each shader lib.

Move the add_dependencies() loop above the if/else so the dependency is declared in both paths. The custom-copy command stays inside the non-Xcode branch since XCODE_EMBED_RESOURCES already handles copying.

Tested by removing the matching add_dependencies() workaround in our downstream caller (Organic Maps' dev_sandbox target) and verifying that the shader library is rebuilt before being embedded under 'cmake -G Xcode' with parallel xcodebuild.