### PR TITLE
Rediscover toolchain as needed

### DIFF
--- a/cmake/CMakeMetalCompiler.cmake.in
+++ b/cmake/CMakeMetalCompiler.cmake.in
@@ -10,6 +10,29 @@ set(CMAKE_Metal_COMPILER "@CMAKE_Metal_COMPILER@")
 set(CMAKE_Metal_COMPILER_ID "@CMAKE_Metal_COMPILER_ID@")
 set(CMAKE_Metal_COMPILER_VERSION "@CMAKE_Metal_COMPILER_VERSION@")
 
+if(NOT EXISTS "${CMAKE_Metal_COMPILER}" AND CMAKE_Metal_COMPILER_ID STREQUAL "Apple")
+    if("${CMAKE_GENERATOR}" STREQUAL "Xcode" OR (APPLE AND CMAKE_VERSION VERSION_GREATER_EQUAL "4.0"))
+        set(CMAKE_Metal_COMPILER_XCODE_TYPE sourcecode.metal)
+        execute_process(COMMAND xcrun --find metal
+            OUTPUT_VARIABLE _xcrun_out OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_VARIABLE _xcrun_err RESULT_VARIABLE _xcrun_result
+        )
+        if(_xcrun_result EQUAL 0 AND EXISTS "${_xcrun_out}")
+            execute_process(
+                COMMAND "${_xcrun_out}" --version
+                OUTPUT_VARIABLE output ERROR_VARIABLE output
+                RESULT_VARIABLE result
+                TIMEOUT 10
+            )
+            if(output MATCHES [[metal version ([0-9]+\.[0-9]+(\.[0-9]+)?)]])
+                if(CMAKE_Metal_COMPILER_VERSION VERSION_EQUAL "${CMAKE_MATCH_1}")
+                    set(CMAKE_Metal_COMPILER "${_xcrun_out}")
+                endif()
+            endif()
+        endif()
+    endif()
+endif()
+
 set(CMAKE_Metal_COMPILER_LOADED 1)
 set(CMAKE_Metal_COMPILER_WORKS "@CMAKE_Metal_COMPILER_WORKS@")
 


### PR DESCRIPTION
Fixes #10

I got to the bottom of the issue and prepared a fix that suits my use case and likely that of others.

## The problem

Apple decided to put some important/critical system components into encrypted, read-only disk images which are mounted on demand. The Metal toolchain is one such component. It is not mounted until either Xcode is launched or some `xcrun` et al. command is run.

The reason why after reboots the first configuration fails, is that the mount location has a random hash component, but the full path to the Metal compiler is baked into `<binary_dir>/CMakeFiles/<cmake_ver>/CMakeMetalCompiler.cmake`. Upon first post-reboot configuration, when `project(A LANGUAGES Metal)` is called, the module-supplied `CMakeDetermineMetalCompiler.cmake` isn't consulted because the cached results are found on disk. The cached path is stale and some check fails resulting in a configuration time error _and_ the deletion of the stale cache file. Thus during the _second_ post-reboot configuration `CMakeDetermineMetalCompiler.cmake` is consulted again, which in turn calls `xcrun --find metal` mounting the toolchain again.

## Solutions

Detecting the staleness of the cached compiler path in theory could be done elegantly from `MetalShaderSupport.cmake`, however the variable `CMAKE_PLATFORM_INFO_DIR` used to find the location of the toolchain cache file isn't defined when non-CMake machinery runs. Otherwise detecting the staleness there and deleting the file before `project()` is reached for a clean toolchain detection would be nice. The workaround is the reiterate some of the detection logic in the cache file itself. If the compiler "disappeared" and if it finds a compiler of the same version as previously, then it overwrites the cached variable.